### PR TITLE
Setting max version for warp, as API changed in 2.1

### DIFF
--- a/hubbub.cabal
+++ b/hubbub.cabal
@@ -101,8 +101,8 @@ executable hubbub-mock-subscriber
                         , wai
                         , wai-extra
                         , wai-middleware-static
-                        , wai-websockets
-                        , warp
+                        , wai-websockets < 2.1
+                        , warp < 2.1
                            
   ghc-options:          -Wall -Werror
   default-language:     Haskell2010


### PR DESCRIPTION
Just a small fix to make sure haskell-hubbub builds in a fresh sandbox. Changes to libraries:
- In Web.Scotty, reqHeader is renamed header
- In Network.Wai.Handler.WebSockets, intercept is gone (or renamed & types have all changed)

It would probably be better to update haskell-hubbub, but that's a bit beyond me ATM.
